### PR TITLE
Add consultant profiles and persistence

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -10,8 +10,10 @@ A FastAPI application that enables Slalom consultants to register their capabili
 
 - View all available consulting capabilities
 - Register consultant expertise and availability
-- Track skill levels and certifications
+- Track consultant skill levels, certifications, and industry preferences
+- Browse a consultant directory with registered capabilities
 - Manage capability capacity and team assignments
+- Persist consultant and capability data in a local JSON store
 
 ## Getting Started
 
@@ -36,8 +38,9 @@ A FastAPI application that enables Slalom consultants to register their capabili
 
 | Method | Endpoint                                                          | Description                                                         |
 | ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
-| GET    | `/capabilities`                                                   | Get all capabilities with details and current consultant assignments |
-| POST   | `/capabilities/{capability_name}/register?email=consultant@slalom.com` | Register consultant for a capability                     |
+| GET    | `/capabilities`                                                   | Get all capabilities with current consultant profile assignments    |
+| GET    | `/consultants`                                                    | Get all consultant profiles and their registered capabilities       |
+| POST   | `/capabilities/{capability_name}/register`                        | Register or enrich a consultant profile for a capability            |
 | DELETE | `/capabilities/{capability_name}/unregister?email=consultant@slalom.com` | Unregister consultant from a capability              |
 
 ## Data Model
@@ -50,7 +53,7 @@ The application uses a consulting-focused data model:
    - Practice area (Strategy, Technology, Operations)
    - Industry verticals served
    - Required certifications
-   - List of consultant emails registered
+   - List of registered consultant references
    - Available capacity (hours per week)
    - Geographic location preferences
 
@@ -60,8 +63,10 @@ The application uses a consulting-focused data model:
    - Skill level
    - Certifications
    - Availability
+   - Preferred industries
+   - Registered capabilities
 
-All data is currently stored in memory for this learning exercise. In a production environment, this would be backed by a robust database system.
+All data is now stored in `src/data/consulting_data.json` for this learning exercise so consultant profiles and registrations survive application restarts. In a production environment, this would be backed by a robust database system.
 
 ## Future Enhancements
 

--- a/src/app.py
+++ b/src/app.py
@@ -5,11 +5,15 @@ A FastAPI application that enables Slalom consultants to register their
 capabilities and manage consulting expertise across the organization.
 """
 
-from fastapi import FastAPI, HTTPException
-from fastapi.staticfiles import StaticFiles
-from fastapi.responses import RedirectResponse
+import json
 import os
 from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import RedirectResponse
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel, Field
 
 app = FastAPI(title="Slalom Capabilities Management API",
               description="API for managing consulting capabilities and consultant expertise")
@@ -18,91 +22,91 @@ app = FastAPI(title="Slalom Capabilities Management API",
 current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
+data_file = current_dir / "data" / "consulting_data.json"
 
-# In-memory capabilities database
-capabilities = {
-    "Cloud Architecture": {
-        "description": "Design and implement scalable cloud solutions using AWS, Azure, and GCP",
-        "practice_area": "Technology",
-        "skill_levels": ["Emerging", "Proficient", "Advanced", "Expert"],
-        "certifications": ["AWS Solutions Architect", "Azure Architect Expert"],
-        "industry_verticals": ["Healthcare", "Financial Services", "Retail"],
-        "capacity": 40,  # hours per week available across team
-        "consultants": ["alice.smith@slalom.com", "bob.johnson@slalom.com"]
-    },
-    "Data Analytics": {
-        "description": "Advanced data analysis, visualization, and machine learning solutions",
-        "practice_area": "Technology", 
-        "skill_levels": ["Emerging", "Proficient", "Advanced", "Expert"],
-        "certifications": ["Tableau Desktop Specialist", "Power BI Expert", "Google Analytics"],
-        "industry_verticals": ["Retail", "Healthcare", "Manufacturing"],
-        "capacity": 35,
-        "consultants": ["emma.davis@slalom.com", "sophia.wilson@slalom.com"]
-    },
-    "DevOps Engineering": {
-        "description": "CI/CD pipeline design, infrastructure automation, and containerization",
-        "practice_area": "Technology",
-        "skill_levels": ["Emerging", "Proficient", "Advanced", "Expert"], 
-        "certifications": ["Docker Certified Associate", "Kubernetes Admin", "Jenkins Certified"],
-        "industry_verticals": ["Technology", "Financial Services"],
-        "capacity": 30,
-        "consultants": ["john.brown@slalom.com", "olivia.taylor@slalom.com"]
-    },
-    "Digital Strategy": {
-        "description": "Digital transformation planning and strategic technology roadmaps",
-        "practice_area": "Strategy",
-        "skill_levels": ["Emerging", "Proficient", "Advanced", "Expert"],
-        "certifications": ["Digital Transformation Certificate", "Agile Certified Practitioner"],
-        "industry_verticals": ["Healthcare", "Financial Services", "Government"],
-        "capacity": 25,
-        "consultants": ["liam.anderson@slalom.com", "noah.martinez@slalom.com"]
-    },
-    "Change Management": {
-        "description": "Organizational change leadership and adoption strategies",
-        "practice_area": "Operations",
-        "skill_levels": ["Emerging", "Proficient", "Advanced", "Expert"],
-        "certifications": ["Prosci Certified", "Lean Six Sigma Black Belt"],
-        "industry_verticals": ["Healthcare", "Manufacturing", "Government"],
-        "capacity": 20,
-        "consultants": ["ava.garcia@slalom.com", "mia.rodriguez@slalom.com"]
-    },
-    "UX/UI Design": {
-        "description": "User experience design and digital product innovation",
-        "practice_area": "Technology",
-        "skill_levels": ["Emerging", "Proficient", "Advanced", "Expert"],
-        "certifications": ["Adobe Certified Expert", "Google UX Design Certificate"],
-        "industry_verticals": ["Retail", "Healthcare", "Technology"],
-        "capacity": 30,
-        "consultants": ["amelia.lee@slalom.com", "harper.white@slalom.com"]
-    },
-    "Cybersecurity": {
-        "description": "Information security strategy, risk assessment, and compliance",
-        "practice_area": "Technology",
-        "skill_levels": ["Emerging", "Proficient", "Advanced", "Expert"],
-        "certifications": ["CISSP", "CISM", "CompTIA Security+"],
-        "industry_verticals": ["Financial Services", "Healthcare", "Government"],
-        "capacity": 25,
-        "consultants": ["ella.clark@slalom.com", "scarlett.lewis@slalom.com"]
-    },
-    "Business Intelligence": {
-        "description": "Enterprise reporting, data warehousing, and business analytics",
-        "practice_area": "Technology",
-        "skill_levels": ["Emerging", "Proficient", "Advanced", "Expert"],
-        "certifications": ["Microsoft BI Certification", "Qlik Sense Certified"],
-        "industry_verticals": ["Retail", "Manufacturing", "Financial Services"],
-        "capacity": 35,
-        "consultants": ["james.walker@slalom.com", "benjamin.hall@slalom.com"]
-    },
-    "Agile Coaching": {
-        "description": "Agile transformation and team coaching for scaled delivery",
-        "practice_area": "Operations",
-        "skill_levels": ["Emerging", "Proficient", "Advanced", "Expert"],
-        "certifications": ["Certified Scrum Master", "SAFe Agilist", "ICAgile Certified"],
-        "industry_verticals": ["Technology", "Financial Services", "Healthcare"],
-        "capacity": 20,
-        "consultants": ["charlotte.young@slalom.com", "henry.king@slalom.com"]
+
+class ConsultantRegistration(BaseModel):
+    email: str
+    name: str = ""
+    practice_area: str = ""
+    skill_level: str = ""
+    certifications: List[str] = Field(default_factory=list)
+    availability: Optional[int] = None
+    preferred_industries: List[str] = Field(default_factory=list)
+
+
+def load_data() -> Dict[str, Any]:
+    with data_file.open("r", encoding="utf-8") as file_handle:
+        return json.load(file_handle)
+
+
+def save_data(data: Dict[str, Any]) -> None:
+    with data_file.open("w", encoding="utf-8") as file_handle:
+        json.dump(data, file_handle, indent=2)
+
+
+def normalize_text(value: str) -> str:
+    return value.strip()
+
+
+def normalize_list(values: List[str]) -> List[str]:
+    cleaned = [normalize_text(value) for value in values if normalize_text(value)]
+    return list(dict.fromkeys(cleaned))
+
+
+def build_consultant_profile(email: str, consultant: Dict[str, Any], capabilities: Dict[str, Any]) -> Dict[str, Any]:
+    registered_capabilities = sorted(
+        capability_name
+        for capability_name, capability in capabilities.items()
+        if email in capability.get("consultants", [])
+    )
+    return {
+        "email": email,
+        "name": consultant.get("name", email),
+        "practice_area": consultant.get("practice_area", ""),
+        "skill_level": consultant.get("skill_level", ""),
+        "certifications": consultant.get("certifications", []),
+        "availability": consultant.get("availability"),
+        "preferred_industries": consultant.get("preferred_industries", []),
+        "registered_capabilities": registered_capabilities,
     }
-}
+
+
+def build_capabilities_response(data: Dict[str, Any]) -> Dict[str, Any]:
+    consultants = data.get("consultants", {})
+    capabilities = data.get("capabilities", {})
+    response = {}
+
+    for capability_name, capability in capabilities.items():
+        consultant_profiles = [
+            build_consultant_profile(email, consultants.get(email, {}), capabilities)
+            for email in capability.get("consultants", [])
+        ]
+        consultant_profiles.sort(key=lambda item: item["name"])
+
+        response[capability_name] = {
+            **capability,
+            "consultants": consultant_profiles,
+            "consultant_count": len(consultant_profiles),
+        }
+
+    return response
+
+
+def build_consultants_response(data: Dict[str, Any]) -> List[Dict[str, Any]]:
+    capabilities = data.get("capabilities", {})
+    consultants = data.get("consultants", {})
+    profiles = [
+        build_consultant_profile(email, consultant, capabilities)
+        for email, consultant in consultants.items()
+    ]
+    profiles.sort(key=lambda item: item["name"])
+    return profiles
+
+
+def default_name_from_email(email: str) -> str:
+    local_part = email.split("@", maxsplit=1)[0]
+    return local_part.replace(".", " ").replace("_", " ").title()
 
 
 @app.get("/")
@@ -112,48 +116,74 @@ def root():
 
 @app.get("/capabilities")
 def get_capabilities():
-    return capabilities
+    return build_capabilities_response(load_data())
+
+
+@app.get("/consultants")
+def get_consultants():
+    return build_consultants_response(load_data())
 
 
 @app.post("/capabilities/{capability_name}/register")
-def register_for_capability(capability_name: str, email: str):
-    """Register a consultant for a capability"""
-    # Validate capability exists
+def register_for_capability(capability_name: str, consultant: ConsultantRegistration):
+    """Register a consultant for a capability and persist their profile."""
+    data = load_data()
+    capabilities = data.get("capabilities", {})
+    consultants = data.get("consultants", {})
+
     if capability_name not in capabilities:
         raise HTTPException(status_code=404, detail="Capability not found")
 
-    # Get the specific capability
+    email = normalize_text(consultant.email).lower()
+    if not email:
+        raise HTTPException(status_code=400, detail="Consultant email is required")
+
     capability = capabilities[capability_name]
 
-    # Validate consultant is not already registered
-    if email in capability["consultants"]:
+    if email in capability.get("consultants", []):
         raise HTTPException(
             status_code=400,
             detail="Consultant is already registered for this capability"
         )
 
-    # Add consultant
-    capability["consultants"].append(email)
-    return {"message": f"Registered {email} for {capability_name}"}
+    existing_profile = consultants.get(email, {})
+    consultants[email] = {
+        "name": normalize_text(consultant.name) or existing_profile.get("name") or default_name_from_email(email),
+        "practice_area": normalize_text(consultant.practice_area) or existing_profile.get("practice_area") or capability.get("practice_area", ""),
+        "skill_level": normalize_text(consultant.skill_level) or existing_profile.get("skill_level") or capability.get("skill_levels", [""])[0],
+        "certifications": normalize_list(consultant.certifications) or existing_profile.get("certifications", []),
+        "availability": consultant.availability if consultant.availability is not None else existing_profile.get("availability", 40),
+        "preferred_industries": normalize_list(consultant.preferred_industries) or existing_profile.get("preferred_industries", []),
+    }
+
+    capability.setdefault("consultants", []).append(email)
+    save_data(data)
+
+    return {
+        "message": f"Registered {consultants[email]['name']} for {capability_name}",
+        "consultant": build_consultant_profile(email, consultants[email], capabilities),
+    }
 
 
 @app.delete("/capabilities/{capability_name}/unregister")
 def unregister_from_capability(capability_name: str, email: str):
     """Unregister a consultant from a capability"""
-    # Validate capability exists
+    data = load_data()
+    capabilities = data.get("capabilities", {})
+
     if capability_name not in capabilities:
         raise HTTPException(status_code=404, detail="Capability not found")
 
-    # Get the specific capability
     capability = capabilities[capability_name]
+    normalized_email = normalize_text(email).lower()
 
-    # Validate consultant is registered
-    if email not in capability["consultants"]:
+    if normalized_email not in capability.get("consultants", []):
         raise HTTPException(
             status_code=400,
             detail="Consultant is not registered for this capability"
         )
 
-    # Remove consultant
-    capability["consultants"].remove(email)
-    return {"message": f"Unregistered {email} from {capability_name}"}
+    capability["consultants"].remove(normalized_email)
+    save_data(data)
+
+    return {"message": f"Unregistered {normalized_email} from {capability_name}"}

--- a/src/app.py
+++ b/src/app.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, List, Optional
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import RedirectResponse
 from fastapi.staticfiles import StaticFiles
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, EmailStr, Field, validator
 
 app = FastAPI(title="Slalom Capabilities Management API",
               description="API for managing consulting capabilities and consultant expertise")
@@ -26,13 +26,64 @@ data_file = current_dir / "data" / "consulting_data.json"
 
 
 class ConsultantRegistration(BaseModel):
-    email: str
+    email: EmailStr
     name: str = ""
     practice_area: str = ""
     skill_level: str = ""
     certifications: List[str] = Field(default_factory=list)
-    availability: Optional[int] = None
+    availability: Optional[int] = Field(default=None, ge=0, le=40)
     preferred_industries: List[str] = Field(default_factory=list)
+
+    @validator("practice_area")
+    def validate_practice_area(cls, value: str) -> str:
+        """Normalize and validate practice area if provided."""
+        if value is None:
+            return ""
+        normalized = value.strip()
+        if not normalized:
+            # Allow empty / unspecified practice area
+            return ""
+        allowed_practice_areas = {
+            "Strategy",
+            "Technology",
+            "Operations",
+            "Sales",
+            "Finance",
+            "Data & Analytics",
+        }
+        if normalized not in allowed_practice_areas:
+            raise ValueError("Unsupported practice_area value")
+        return normalized
+
+    @validator("skill_level")
+    def validate_skill_level(cls, value: str) -> str:
+        """Normalize and validate skill level if provided."""
+        if value is None:
+            return ""
+        normalized = value.strip()
+        if not normalized:
+            # Allow empty / unspecified skill level
+            return ""
+        allowed_skill_levels = {
+            "Junior",
+            "Mid",
+            "Senior",
+            "Principal",
+            "Director",
+        }
+        if normalized not in allowed_skill_levels:
+            raise ValueError("Unsupported skill_level value")
+        return normalized
+
+    @validator("certifications", "preferred_industries", each_item=True)
+    def normalize_list_items(cls, value: str) -> str:
+        """Trim whitespace from list items and reject empty entries."""
+        if value is None:
+            raise ValueError("List items must be non-empty strings")
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("List items must be non-empty strings")
+        return normalized
 
 
 def load_data() -> Dict[str, Any]:

--- a/src/app.py
+++ b/src/app.py
@@ -202,10 +202,18 @@ def register_for_capability(capability_name: str, consultant: ConsultantRegistra
         )
 
     existing_profile = consultants.get(email, {})
+
+    # Determine a safe default skill level from the capability definition.
+    skill_levels = capability.get("skill_levels") or []
+    if isinstance(skill_levels, list) and skill_levels:
+        default_skill_level = skill_levels[0]
+    else:
+        default_skill_level = ""
+
     consultants[email] = {
         "name": normalize_text(consultant.name) or existing_profile.get("name") or default_name_from_email(email),
         "practice_area": normalize_text(consultant.practice_area) or existing_profile.get("practice_area") or capability.get("practice_area", ""),
-        "skill_level": normalize_text(consultant.skill_level) or existing_profile.get("skill_level") or capability.get("skill_levels", [""])[0],
+        "skill_level": normalize_text(consultant.skill_level) or existing_profile.get("skill_level") or default_skill_level,
         "certifications": normalize_list(consultant.certifications) or existing_profile.get("certifications", []),
         "availability": consultant.availability if consultant.availability is not None else existing_profile.get("availability", 40),
         "preferred_industries": normalize_list(consultant.preferred_industries) or existing_profile.get("preferred_industries", []),

--- a/src/app.py
+++ b/src/app.py
@@ -50,7 +50,11 @@ def normalize_text(value: str) -> str:
 
 
 def normalize_list(values: List[str]) -> List[str]:
-    cleaned = [normalize_text(value) for value in values if normalize_text(value)]
+    cleaned: List[str] = []
+    for value in values:
+        normalized = normalize_text(value)
+        if normalized:
+            cleaned.append(normalized)
     return list(dict.fromkeys(cleaned))
 
 

--- a/src/data/consulting_data.json
+++ b/src/data/consulting_data.json
@@ -1,0 +1,231 @@
+{
+  "capabilities": {
+    "Cloud Architecture": {
+      "description": "Design and implement scalable cloud solutions using AWS, Azure, and GCP",
+      "practice_area": "Technology",
+      "skill_levels": ["Emerging", "Proficient", "Advanced", "Expert"],
+      "certifications": ["AWS Solutions Architect", "Azure Architect Expert"],
+      "industry_verticals": ["Healthcare", "Financial Services", "Retail"],
+      "capacity": 40,
+      "consultants": ["alice.smith@slalom.com", "bob.johnson@slalom.com"]
+    },
+    "Data Analytics": {
+      "description": "Advanced data analysis, visualization, and machine learning solutions",
+      "practice_area": "Technology",
+      "skill_levels": ["Emerging", "Proficient", "Advanced", "Expert"],
+      "certifications": ["Tableau Desktop Specialist", "Power BI Expert", "Google Analytics"],
+      "industry_verticals": ["Retail", "Healthcare", "Manufacturing"],
+      "capacity": 35,
+      "consultants": ["emma.davis@slalom.com", "sophia.wilson@slalom.com"]
+    },
+    "DevOps Engineering": {
+      "description": "CI/CD pipeline design, infrastructure automation, and containerization",
+      "practice_area": "Technology",
+      "skill_levels": ["Emerging", "Proficient", "Advanced", "Expert"],
+      "certifications": ["Docker Certified Associate", "Kubernetes Admin", "Jenkins Certified"],
+      "industry_verticals": ["Technology", "Financial Services"],
+      "capacity": 30,
+      "consultants": ["john.brown@slalom.com", "olivia.taylor@slalom.com"]
+    },
+    "Digital Strategy": {
+      "description": "Digital transformation planning and strategic technology roadmaps",
+      "practice_area": "Strategy",
+      "skill_levels": ["Emerging", "Proficient", "Advanced", "Expert"],
+      "certifications": ["Digital Transformation Certificate", "Agile Certified Practitioner"],
+      "industry_verticals": ["Healthcare", "Financial Services", "Government"],
+      "capacity": 25,
+      "consultants": ["liam.anderson@slalom.com", "noah.martinez@slalom.com"]
+    },
+    "Change Management": {
+      "description": "Organizational change leadership and adoption strategies",
+      "practice_area": "Operations",
+      "skill_levels": ["Emerging", "Proficient", "Advanced", "Expert"],
+      "certifications": ["Prosci Certified", "Lean Six Sigma Black Belt"],
+      "industry_verticals": ["Healthcare", "Manufacturing", "Government"],
+      "capacity": 20,
+      "consultants": ["ava.garcia@slalom.com", "mia.rodriguez@slalom.com"]
+    },
+    "UX/UI Design": {
+      "description": "User experience design and digital product innovation",
+      "practice_area": "Technology",
+      "skill_levels": ["Emerging", "Proficient", "Advanced", "Expert"],
+      "certifications": ["Adobe Certified Expert", "Google UX Design Certificate"],
+      "industry_verticals": ["Retail", "Healthcare", "Technology"],
+      "capacity": 30,
+      "consultants": ["amelia.lee@slalom.com", "harper.white@slalom.com"]
+    },
+    "Cybersecurity": {
+      "description": "Information security strategy, risk assessment, and compliance",
+      "practice_area": "Technology",
+      "skill_levels": ["Emerging", "Proficient", "Advanced", "Expert"],
+      "certifications": ["CISSP", "CISM", "CompTIA Security+"],
+      "industry_verticals": ["Financial Services", "Healthcare", "Government"],
+      "capacity": 25,
+      "consultants": ["ella.clark@slalom.com", "scarlett.lewis@slalom.com"]
+    },
+    "Business Intelligence": {
+      "description": "Enterprise reporting, data warehousing, and business analytics",
+      "practice_area": "Technology",
+      "skill_levels": ["Emerging", "Proficient", "Advanced", "Expert"],
+      "certifications": ["Microsoft BI Certification", "Qlik Sense Certified"],
+      "industry_verticals": ["Retail", "Manufacturing", "Financial Services"],
+      "capacity": 35,
+      "consultants": ["james.walker@slalom.com", "benjamin.hall@slalom.com"]
+    },
+    "Agile Coaching": {
+      "description": "Agile transformation and team coaching for scaled delivery",
+      "practice_area": "Operations",
+      "skill_levels": ["Emerging", "Proficient", "Advanced", "Expert"],
+      "certifications": ["Certified Scrum Master", "SAFe Agilist", "ICAgile Certified"],
+      "industry_verticals": ["Technology", "Financial Services", "Healthcare"],
+      "capacity": 20,
+      "consultants": ["charlotte.young@slalom.com", "henry.king@slalom.com"]
+    }
+  },
+  "consultants": {
+    "alice.smith@slalom.com": {
+      "name": "Alice Smith",
+      "practice_area": "Technology",
+      "skill_level": "Expert",
+      "certifications": ["AWS Solutions Architect", "Azure Architect Expert"],
+      "availability": 32,
+      "preferred_industries": ["Healthcare", "Financial Services"]
+    },
+    "bob.johnson@slalom.com": {
+      "name": "Bob Johnson",
+      "practice_area": "Technology",
+      "skill_level": "Advanced",
+      "certifications": ["AWS Solutions Architect"],
+      "availability": 24,
+      "preferred_industries": ["Retail", "Financial Services"]
+    },
+    "emma.davis@slalom.com": {
+      "name": "Emma Davis",
+      "practice_area": "Technology",
+      "skill_level": "Expert",
+      "certifications": ["Tableau Desktop Specialist", "Power BI Expert"],
+      "availability": 28,
+      "preferred_industries": ["Retail", "Healthcare"]
+    },
+    "sophia.wilson@slalom.com": {
+      "name": "Sophia Wilson",
+      "practice_area": "Technology",
+      "skill_level": "Advanced",
+      "certifications": ["Google Analytics"],
+      "availability": 30,
+      "preferred_industries": ["Manufacturing", "Healthcare"]
+    },
+    "john.brown@slalom.com": {
+      "name": "John Brown",
+      "practice_area": "Technology",
+      "skill_level": "Expert",
+      "certifications": ["Docker Certified Associate", "Kubernetes Admin"],
+      "availability": 35,
+      "preferred_industries": ["Technology", "Financial Services"]
+    },
+    "olivia.taylor@slalom.com": {
+      "name": "Olivia Taylor",
+      "practice_area": "Technology",
+      "skill_level": "Advanced",
+      "certifications": ["Jenkins Certified"],
+      "availability": 20,
+      "preferred_industries": ["Technology"]
+    },
+    "liam.anderson@slalom.com": {
+      "name": "Liam Anderson",
+      "practice_area": "Strategy",
+      "skill_level": "Expert",
+      "certifications": ["Digital Transformation Certificate"],
+      "availability": 18,
+      "preferred_industries": ["Healthcare", "Government"]
+    },
+    "noah.martinez@slalom.com": {
+      "name": "Noah Martinez",
+      "practice_area": "Strategy",
+      "skill_level": "Advanced",
+      "certifications": ["Agile Certified Practitioner"],
+      "availability": 20,
+      "preferred_industries": ["Financial Services", "Government"]
+    },
+    "ava.garcia@slalom.com": {
+      "name": "Ava Garcia",
+      "practice_area": "Operations",
+      "skill_level": "Expert",
+      "certifications": ["Prosci Certified"],
+      "availability": 22,
+      "preferred_industries": ["Healthcare", "Government"]
+    },
+    "mia.rodriguez@slalom.com": {
+      "name": "Mia Rodriguez",
+      "practice_area": "Operations",
+      "skill_level": "Advanced",
+      "certifications": ["Lean Six Sigma Black Belt"],
+      "availability": 24,
+      "preferred_industries": ["Manufacturing"]
+    },
+    "amelia.lee@slalom.com": {
+      "name": "Amelia Lee",
+      "practice_area": "Technology",
+      "skill_level": "Expert",
+      "certifications": ["Adobe Certified Expert"],
+      "availability": 26,
+      "preferred_industries": ["Retail", "Technology"]
+    },
+    "harper.white@slalom.com": {
+      "name": "Harper White",
+      "practice_area": "Technology",
+      "skill_level": "Advanced",
+      "certifications": ["Google UX Design Certificate"],
+      "availability": 30,
+      "preferred_industries": ["Healthcare", "Technology"]
+    },
+    "ella.clark@slalom.com": {
+      "name": "Ella Clark",
+      "practice_area": "Technology",
+      "skill_level": "Expert",
+      "certifications": ["CISSP"],
+      "availability": 25,
+      "preferred_industries": ["Financial Services", "Government"]
+    },
+    "scarlett.lewis@slalom.com": {
+      "name": "Scarlett Lewis",
+      "practice_area": "Technology",
+      "skill_level": "Advanced",
+      "certifications": ["CISM", "CompTIA Security+"],
+      "availability": 20,
+      "preferred_industries": ["Healthcare", "Government"]
+    },
+    "james.walker@slalom.com": {
+      "name": "James Walker",
+      "practice_area": "Technology",
+      "skill_level": "Expert",
+      "certifications": ["Microsoft BI Certification"],
+      "availability": 28,
+      "preferred_industries": ["Retail", "Manufacturing"]
+    },
+    "benjamin.hall@slalom.com": {
+      "name": "Benjamin Hall",
+      "practice_area": "Technology",
+      "skill_level": "Advanced",
+      "certifications": ["Qlik Sense Certified"],
+      "availability": 30,
+      "preferred_industries": ["Financial Services"]
+    },
+    "charlotte.young@slalom.com": {
+      "name": "Charlotte Young",
+      "practice_area": "Operations",
+      "skill_level": "Expert",
+      "certifications": ["Certified Scrum Master", "SAFe Agilist"],
+      "availability": 18,
+      "preferred_industries": ["Technology", "Healthcare"]
+    },
+    "henry.king@slalom.com": {
+      "name": "Henry King",
+      "practice_area": "Operations",
+      "skill_level": "Advanced",
+      "certifications": ["ICAgile Certified"],
+      "availability": 20,
+      "preferred_industries": ["Financial Services", "Healthcare"]
+    }
+  }
+}

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -96,47 +96,123 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   async function fetchConsultants() {
+    // Helper to safely render badge-like tags into a container element
+    function appendBadges(container, values, fallbackText) {
+      let items = [];
+
+      if (Array.isArray(values)) {
+        items = values;
+      } else if (typeof values === "string" && values.trim() !== "") {
+        items = parseCommaSeparated(values);
+      }
+
+      if (!items.length) {
+        const fallbackSpan = document.createElement("span");
+        fallbackSpan.textContent = fallbackText;
+        container.appendChild(fallbackSpan);
+        return;
+      }
+
+      items.forEach((item) => {
+        const badge = document.createElement("span");
+        badge.textContent = item;
+        container.appendChild(badge);
+      });
+    }
+
     try {
       const response = await fetch("/consultants");
       const consultants = await response.json();
 
+      // Clear any existing content
+      consultantsList.textContent = "";
+
       if (!consultants.length) {
-        consultantsList.innerHTML = "<p>No consultant profiles found yet.</p>";
+        const p = document.createElement("p");
+        p.textContent = "No consultant profiles found yet.";
+        consultantsList.appendChild(p);
         return;
       }
 
-      consultantsList.innerHTML = consultants
-        .map(
-          (consultant) => `
-            <article class="consultant-card">
-              <div class="consultant-card-header">
-                <div>
-                  <h4>${consultant.name}</h4>
-                  <p>${consultant.email}</p>
-                </div>
-                <span class="skill-pill">${consultant.skill_level || "Unrated"}</span>
-              </div>
-              <p><strong>Practice Area:</strong> ${consultant.practice_area || "Not set"}</p>
-              <p><strong>Availability:</strong> ${consultant.availability ?? "Not set"} hours/week</p>
-              <div>
-                <strong>Certifications:</strong>
-                <div class="tag-group">${renderConsultantBadges(consultant.certifications, "No certifications")}</div>
-              </div>
-              <div>
-                <strong>Preferred Industries:</strong>
-                <div class="tag-group">${renderConsultantBadges(consultant.preferred_industries, "No industry preferences")}</div>
-              </div>
-              <div>
-                <strong>Registered Capabilities:</strong>
-                <div class="tag-group">${renderConsultantBadges(consultant.registered_capabilities, "No capabilities registered")}</div>
-              </div>
-            </article>
-          `
-        )
-        .join("");
+      consultants.forEach((consultant) => {
+        const article = document.createElement("article");
+        article.className = "consultant-card";
+
+        const header = document.createElement("div");
+        header.className = "consultant-card-header";
+
+        const headerInfo = document.createElement("div");
+
+        const nameEl = document.createElement("h4");
+        nameEl.textContent = consultant.name || "";
+
+        const emailEl = document.createElement("p");
+        emailEl.textContent = consultant.email || "";
+
+        headerInfo.appendChild(nameEl);
+        headerInfo.appendChild(emailEl);
+
+        const skillPill = document.createElement("span");
+        skillPill.className = "skill-pill";
+        skillPill.textContent = consultant.skill_level || "Unrated";
+
+        header.appendChild(headerInfo);
+        header.appendChild(skillPill);
+
+        const practicePara = document.createElement("p");
+        const practiceStrong = document.createElement("strong");
+        practiceStrong.textContent = "Practice Area:";
+        practicePara.appendChild(practiceStrong);
+        practicePara.appendChild(document.createTextNode(" " + (consultant.practice_area || "Not set")));
+
+        const availabilityPara = document.createElement("p");
+        const availabilityStrong = document.createElement("strong");
+        availabilityStrong.textContent = "Availability:";
+        availabilityPara.appendChild(availabilityStrong);
+        const availabilityText = consultant.availability ?? "Not set";
+        availabilityPara.appendChild(document.createTextNode(" " + availabilityText + " hours/week"));
+
+        const certificationsDiv = document.createElement("div");
+        const certificationsStrong = document.createElement("strong");
+        certificationsStrong.textContent = "Certifications:";
+        const certificationsTagGroup = document.createElement("div");
+        certificationsTagGroup.className = "tag-group";
+        appendBadges(certificationsTagGroup, consultant.certifications, "No certifications");
+        certificationsDiv.appendChild(certificationsStrong);
+        certificationsDiv.appendChild(certificationsTagGroup);
+
+        const industriesDiv = document.createElement("div");
+        const industriesStrong = document.createElement("strong");
+        industriesStrong.textContent = "Preferred Industries:";
+        const industriesTagGroup = document.createElement("div");
+        industriesTagGroup.className = "tag-group";
+        appendBadges(industriesTagGroup, consultant.preferred_industries, "No industry preferences");
+        industriesDiv.appendChild(industriesStrong);
+        industriesDiv.appendChild(industriesTagGroup);
+
+        const capabilitiesDiv = document.createElement("div");
+        const capabilitiesStrong = document.createElement("strong");
+        capabilitiesStrong.textContent = "Registered Capabilities:";
+        const capabilitiesTagGroup = document.createElement("div");
+        capabilitiesTagGroup.className = "tag-group";
+        appendBadges(capabilitiesTagGroup, consultant.registered_capabilities, "No capabilities registered");
+        capabilitiesDiv.appendChild(capabilitiesStrong);
+        capabilitiesDiv.appendChild(capabilitiesTagGroup);
+
+        article.appendChild(header);
+        article.appendChild(practicePara);
+        article.appendChild(availabilityPara);
+        article.appendChild(certificationsDiv);
+        article.appendChild(industriesDiv);
+        article.appendChild(capabilitiesDiv);
+
+        consultantsList.appendChild(article);
+      });
     } catch (error) {
-      consultantsList.innerHTML =
-        "<p>Failed to load consultant profiles. Please try again later.</p>";
+      consultantsList.textContent = "";
+      const p = document.createElement("p");
+      p.textContent = "Failed to load consultant profiles. Please try again later.";
+      consultantsList.appendChild(p);
       console.error("Error fetching consultants:", error);
     }
   }

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -12,13 +12,25 @@ document.addEventListener("DOMContentLoaded", () => {
       .filter(Boolean);
   }
 
+  function escapeHtml(value) {
+    if (value === null || value === undefined) {
+      return "";
+    }
+    return String(value)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+  }
+
   function renderConsultantBadges(values, emptyState) {
     if (!values || values.length === 0) {
-      return `<span class="empty-state">${emptyState}</span>`;
+      return `<span class="empty-state">${escapeHtml(emptyState)}</span>`;
     }
 
     return values
-      .map((value) => `<span class="tag">${value}</span>`)
+      .map((value) => `<span class="tag">${escapeHtml(value)}</span>`)
       .join("");
   }
 
@@ -51,10 +63,10 @@ document.addEventListener("DOMContentLoaded", () => {
                     (consultant) =>
                       `<li>
                         <div>
-                          <span class="consultant-email">${consultant.name}</span>
-                          <div class="consultant-meta">${consultant.email} • ${consultant.skill_level || "Unrated"} • ${consultant.availability ?? "?"} hrs/week</div>
+                          <span class="consultant-email">${escapeHtml(consultant.name)}</span>
+                          <div class="consultant-meta">${escapeHtml(consultant.email)} • ${escapeHtml(consultant.skill_level || "Unrated")} • ${escapeHtml(consultant.availability ?? "?")} hrs/week</div>
                         </div>
-                        <button class="delete-btn" data-capability="${name}" data-email="${consultant.email}">Remove</button>
+                        <button class="delete-btn" data-capability="${escapeHtml(name)}" data-email="${escapeHtml(consultant.email)}">Remove</button>
                       </li>`
                   )
                   .join("")}
@@ -63,13 +75,21 @@ document.addEventListener("DOMContentLoaded", () => {
             : `<p><em>No consultants registered yet</em></p>`;
 
         capabilityCard.innerHTML = `
-          <h4>${name}</h4>
-          <p>${details.description}</p>
-          <p><strong>Practice Area:</strong> ${details.practice_area}</p>
-          <p><strong>Industry Verticals:</strong> ${details.industry_verticals ? details.industry_verticals.join(', ') : 'Not specified'}</p>
+          <h4>${escapeHtml(name)}</h4>
+          <p>${escapeHtml(details.description)}</p>
+          <p><strong>Practice Area:</strong> ${escapeHtml(details.practice_area)}</p>
+          <p><strong>Industry Verticals:</strong> ${
+            details.industry_verticals
+              ? details.industry_verticals.map(escapeHtml).join(", ")
+              : "Not specified"
+          }</p>
           <p><strong>Capacity:</strong> ${availableCapacity} hours/week available</p>
           <p><strong>Current Team:</strong> ${currentConsultants} consultants</p>
-          <p><strong>Required Certifications:</strong> ${details.certifications ? details.certifications.join(', ') : 'None listed'}</p>
+          <p><strong>Required Certifications:</strong> ${
+            details.certifications
+              ? details.certifications.map(escapeHtml).join(", ")
+              : "None listed"
+          }</p>
           <div class="consultants-container">
             ${consultantsHTML}
           </div>

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -1,8 +1,26 @@
 document.addEventListener("DOMContentLoaded", () => {
   const capabilitiesList = document.getElementById("capabilities-list");
+  const consultantsList = document.getElementById("consultants-list");
   const capabilitySelect = document.getElementById("capability");
   const registerForm = document.getElementById("register-form");
   const messageDiv = document.getElementById("message");
+
+  function parseCommaSeparated(value) {
+    return value
+      .split(",")
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+  }
+
+  function renderConsultantBadges(values, emptyState) {
+    if (!values || values.length === 0) {
+      return `<span class="empty-state">${emptyState}</span>`;
+    }
+
+    return values
+      .map((value) => `<span class="tag">${value}</span>`)
+      .join("");
+  }
 
   // Function to fetch capabilities from API
   async function fetchCapabilities() {
@@ -12,6 +30,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
       // Clear loading message
       capabilitiesList.innerHTML = "";
+      capabilitySelect.innerHTML = '<option value="">-- Select a capability --</option>';
 
       // Populate capabilities list
       Object.entries(capabilities).forEach(([name, details]) => {
@@ -19,7 +38,7 @@ document.addEventListener("DOMContentLoaded", () => {
         capabilityCard.className = "capability-card";
 
         const availableCapacity = details.capacity || 0;
-        const currentConsultants = details.consultants ? details.consultants.length : 0;
+        const currentConsultants = details.consultant_count || 0;
 
         // Create consultants HTML with delete icons
         const consultantsHTML =
@@ -29,8 +48,14 @@ document.addEventListener("DOMContentLoaded", () => {
               <ul class="consultants-list">
                 ${details.consultants
                   .map(
-                    (email) =>
-                      `<li><span class="consultant-email">${email}</span><button class="delete-btn" data-capability="${name}" data-email="${email}">❌</button></li>`
+                    (consultant) =>
+                      `<li>
+                        <div>
+                          <span class="consultant-email">${consultant.name}</span>
+                          <div class="consultant-meta">${consultant.email} • ${consultant.skill_level || "Unrated"} • ${consultant.availability ?? "?"} hrs/week</div>
+                        </div>
+                        <button class="delete-btn" data-capability="${name}" data-email="${consultant.email}">Remove</button>
+                      </li>`
                   )
                   .join("")}
               </ul>
@@ -44,6 +69,7 @@ document.addEventListener("DOMContentLoaded", () => {
           <p><strong>Industry Verticals:</strong> ${details.industry_verticals ? details.industry_verticals.join(', ') : 'Not specified'}</p>
           <p><strong>Capacity:</strong> ${availableCapacity} hours/week available</p>
           <p><strong>Current Team:</strong> ${currentConsultants} consultants</p>
+          <p><strong>Required Certifications:</strong> ${details.certifications ? details.certifications.join(', ') : 'None listed'}</p>
           <div class="consultants-container">
             ${consultantsHTML}
           </div>
@@ -66,6 +92,52 @@ document.addEventListener("DOMContentLoaded", () => {
       capabilitiesList.innerHTML =
         "<p>Failed to load capabilities. Please try again later.</p>";
       console.error("Error fetching capabilities:", error);
+    }
+  }
+
+  async function fetchConsultants() {
+    try {
+      const response = await fetch("/consultants");
+      const consultants = await response.json();
+
+      if (!consultants.length) {
+        consultantsList.innerHTML = "<p>No consultant profiles found yet.</p>";
+        return;
+      }
+
+      consultantsList.innerHTML = consultants
+        .map(
+          (consultant) => `
+            <article class="consultant-card">
+              <div class="consultant-card-header">
+                <div>
+                  <h4>${consultant.name}</h4>
+                  <p>${consultant.email}</p>
+                </div>
+                <span class="skill-pill">${consultant.skill_level || "Unrated"}</span>
+              </div>
+              <p><strong>Practice Area:</strong> ${consultant.practice_area || "Not set"}</p>
+              <p><strong>Availability:</strong> ${consultant.availability ?? "Not set"} hours/week</p>
+              <div>
+                <strong>Certifications:</strong>
+                <div class="tag-group">${renderConsultantBadges(consultant.certifications, "No certifications")}</div>
+              </div>
+              <div>
+                <strong>Preferred Industries:</strong>
+                <div class="tag-group">${renderConsultantBadges(consultant.preferred_industries, "No industry preferences")}</div>
+              </div>
+              <div>
+                <strong>Registered Capabilities:</strong>
+                <div class="tag-group">${renderConsultantBadges(consultant.registered_capabilities, "No capabilities registered")}</div>
+              </div>
+            </article>
+          `
+        )
+        .join("");
+    } catch (error) {
+      consultantsList.innerHTML =
+        "<p>Failed to load consultant profiles. Please try again later.</p>";
+      console.error("Error fetching consultants:", error);
     }
   }
 
@@ -93,6 +165,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
         // Refresh capabilities list to show updated consultants
         fetchCapabilities();
+        fetchConsultants();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";
@@ -116,16 +189,36 @@ document.addEventListener("DOMContentLoaded", () => {
   registerForm.addEventListener("submit", async (event) => {
     event.preventDefault();
 
-    const email = document.getElementById("email").value;
+    const email = document.getElementById("email").value.trim();
     const capability = document.getElementById("capability").value;
+    const name = document.getElementById("name").value.trim();
+    const practiceArea = document.getElementById("practice-area").value;
+    const skillLevel = document.getElementById("skill-level").value;
+    const availabilityValue = document.getElementById("availability").value;
+    const certifications = parseCommaSeparated(
+      document.getElementById("certifications").value
+    );
+    const preferredIndustries = parseCommaSeparated(
+      document.getElementById("preferred-industries").value
+    );
 
     try {
       const response = await fetch(
-        `/capabilities/${encodeURIComponent(
-          capability
-        )}/register?email=${encodeURIComponent(email)}`,
+        `/capabilities/${encodeURIComponent(capability)}/register`,
         {
           method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            email,
+            name,
+            practice_area: practiceArea,
+            skill_level: skillLevel,
+            availability: availabilityValue ? Number(availabilityValue) : null,
+            certifications,
+            preferred_industries: preferredIndustries,
+          }),
         }
       );
 
@@ -138,6 +231,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
         // Refresh capabilities list to show updated consultants
         fetchCapabilities();
+        fetchConsultants();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";
@@ -159,4 +253,5 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Initialize app
   fetchCapabilities();
+  fetchConsultants();
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -18,14 +18,6 @@
     </header>
 
     <main>
-      <section id="capabilities-container">
-        <h3>Available Capabilities</h3>
-        <div id="capabilities-list">
-          <!-- Capabilities will be loaded here -->
-          <p>Loading capabilities...</p>
-        </div>
-      </section>
-
       <section id="register-container">
         <h3>Register Your Expertise</h3>
         <form id="register-form">
@@ -34,15 +26,68 @@
             <input type="email" id="email" required placeholder="your-email@slalom.com" />
           </div>
           <div class="form-group">
-            <label for="capability">Select Capability:</label>
-            <select id="capability" required>
-              <option value="">-- Select a capability --</option>
-              <!-- Capability options will be loaded here -->
-            </select>
+            <label for="name">Consultant Name:</label>
+            <input type="text" id="name" placeholder="Optional for existing consultants" />
+          </div>
+          <div class="form-row">
+            <div class="form-group">
+              <label for="practice-area">Practice Area:</label>
+              <select id="practice-area">
+                <option value="">Match capability practice area</option>
+                <option value="Strategy">Strategy</option>
+                <option value="Technology">Technology</option>
+                <option value="Operations">Operations</option>
+              </select>
+            </div>
+            <div class="form-group">
+              <label for="skill-level">Skill Level:</label>
+              <select id="skill-level">
+                <option value="">Match capability default</option>
+                <option value="Emerging">Emerging</option>
+                <option value="Proficient">Proficient</option>
+                <option value="Advanced">Advanced</option>
+                <option value="Expert">Expert</option>
+              </select>
+            </div>
+          </div>
+          <div class="form-row">
+            <div class="form-group">
+              <label for="availability">Availability (hours/week):</label>
+              <input type="number" id="availability" min="0" max="40" placeholder="40" />
+            </div>
+            <div class="form-group">
+              <label for="capability">Select Capability:</label>
+              <select id="capability" required>
+                <option value="">-- Select a capability --</option>
+                <!-- Capability options will be loaded here -->
+              </select>
+            </div>
+          </div>
+          <div class="form-group">
+            <label for="certifications">Certifications:</label>
+            <input type="text" id="certifications" placeholder="Comma-separated certifications" />
+          </div>
+          <div class="form-group">
+            <label for="preferred-industries">Preferred Industries:</label>
+            <input type="text" id="preferred-industries" placeholder="Comma-separated industries" />
           </div>
           <button type="submit">Register Expertise</button>
         </form>
         <div id="message" class="hidden"></div>
+      </section>
+
+      <section id="capabilities-container" class="wide-section">
+        <h3>Available Capabilities</h3>
+        <div id="capabilities-list">
+          <p>Loading capabilities...</p>
+        </div>
+      </section>
+
+      <section id="consultants-container" class="wide-section">
+        <h3>Consultant Directory</h3>
+        <div id="consultants-list">
+          <p>Loading consultant profiles...</p>
+        </div>
       </section>
     </main>
 

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -73,6 +73,10 @@ section {
   max-width: 500px;
 }
 
+.wide-section {
+  max-width: 1040px;
+}
+
 section h3 {
   margin-bottom: 20px;
   padding-bottom: 10px;
@@ -147,6 +151,11 @@ section h3 {
   color: #003d7a;
 }
 
+.consultant-meta {
+  color: #5f6b7a;
+  font-size: 0.9rem;
+}
+
 .delete-btn {
   background: linear-gradient(135deg, #ff5722, #d32f2f);
   border: none;
@@ -190,6 +199,12 @@ section h3 {
   border: 1px solid #ddd;
   border-radius: 4px;
   font-size: 16px;
+}
+
+.form-row {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 15px;
 }
 
 button[type="submit"] {
@@ -238,6 +253,66 @@ button[type="submit"]:hover {
 
 .hidden {
   display: none;
+}
+
+#consultants-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
+}
+
+.consultant-card {
+  border: 1px solid #dce7f5;
+  border-radius: 10px;
+  padding: 18px;
+  background: linear-gradient(180deg, #ffffff, #f7fbff);
+  box-shadow: 0 3px 8px rgba(0, 61, 122, 0.08);
+}
+
+.consultant-card h4 {
+  color: #003d7a;
+  margin-bottom: 4px;
+}
+
+.consultant-card p {
+  margin-bottom: 10px;
+}
+
+.consultant-card-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: flex-start;
+  margin-bottom: 12px;
+}
+
+.skill-pill {
+  background: #003d7a;
+  color: white;
+  border-radius: 999px;
+  padding: 6px 10px;
+  font-size: 0.85rem;
+  white-space: nowrap;
+}
+
+.tag-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.tag {
+  background: #e3f2fd;
+  color: #003d7a;
+  border-radius: 999px;
+  padding: 5px 10px;
+  font-size: 0.85rem;
+}
+
+.empty-state {
+  color: #6c757d;
+  font-style: italic;
 }
 
 footer {
@@ -290,6 +365,10 @@ footer {
   .header-content {
     flex-direction: column;
     gap: 10px;
+  }
+
+  .form-row {
+    grid-template-columns: 1fr;
   }
   
   .mascot {


### PR DESCRIPTION
## Summary
- replace in-memory capability storage with a JSON-backed data store
- add first-class consultant profiles and a new consultants API endpoint
- update the UI to capture consultant profile details and display a consultant directory
- refresh the README to document the new persistence model and endpoints

## Testing
- imported the FastAPI app successfully with the configured virtual environment
- validated changed backend and frontend files with editor error checks